### PR TITLE
feat - used_skill_points

### DIFF
--- a/src/main/java/io/github/alathra/alathraskills/AlathraSkills.java
+++ b/src/main/java/io/github/alathra/alathraskills/AlathraSkills.java
@@ -74,13 +74,13 @@ public class AlathraSkills extends JavaPlugin {
 
     @Override
     public void onDisable() {
+        skillsManager.onDisable();
+        skillsPlayerManager.onDisable();
         configHandler.onDisable();
         databaseHandler.onDisable();
         commandHandler.onDisable();
         listenerHandler.onDisable();
         vaultHook.onDisable();
-        skillsManager.onDisable();
-        skillsPlayerManager.onDisable();
     }
 
     /**

--- a/src/main/java/io/github/alathra/alathraskills/api/SkillsPlayer.java
+++ b/src/main/java/io/github/alathra/alathraskills/api/SkillsPlayer.java
@@ -11,12 +11,14 @@ public class SkillsPlayer {
 	private OfflinePlayer p;
 	private HashMap<Integer, SkillDetails> playerSkills;
 	private HashMap<Integer, Float> playerExperienceValues;
+	private Integer usedSkillPoints;
 	
 	public SkillsPlayer(OfflinePlayer p, HashMap<Integer, SkillDetails> playerSkills,
-			HashMap<Integer, Float> playerExperienceValues) {
+			HashMap<Integer, Float> playerExperienceValues, Integer usedSkillPoints) {
 		this.p = p;
 		this.playerSkills = playerSkills;
 		this.playerExperienceValues = playerExperienceValues;
+		this.usedSkillPoints = usedSkillPoints;
 	}
 	
 	public OfflinePlayer getPlayer() {
@@ -89,5 +91,13 @@ public class SkillsPlayer {
 	public void cleanUpInsertedSkills() {
 		getSkillsToInsertToDB().forEach(sd -> playerSkills.put(
 				sd.getKey(), new SkillDetails(true, true)));
+	}
+
+	public Integer getUsedSkillPoints() {
+		return usedSkillPoints;
+	}
+
+	public void setUsedSkillPoints(Integer usedSkillPoints) {
+		this.usedSkillPoints = usedSkillPoints;
 	}
 }

--- a/src/main/java/io/github/alathra/alathraskills/api/commands/TestGetUsedSkillPointsCommandMemory.java
+++ b/src/main/java/io/github/alathra/alathraskills/api/commands/TestGetUsedSkillPointsCommandMemory.java
@@ -1,0 +1,48 @@
+package io.github.alathra.alathraskills.api.commands;
+
+import org.bukkit.entity.Player;
+
+import com.github.milkdrinkers.colorparser.ColorParser;
+
+import dev.jorel.commandapi.CommandAPICommand;
+import dev.jorel.commandapi.arguments.IntegerArgument;
+import dev.jorel.commandapi.arguments.PlayerArgument;
+import dev.jorel.commandapi.executors.CommandArguments;
+import io.github.alathra.alathraskills.api.SkillsPlayerManager;
+import io.github.alathra.alathraskills.db.DatabaseQueries;
+
+public class TestGetUsedSkillPointsCommandMemory {
+
+    public TestGetUsedSkillPointsCommandMemory() {
+        new CommandAPICommand("testGetUsedSkillPoints_memory")
+        	.withArguments(new PlayerArgument("targetPlayer"))
+            .withFullDescription("Get Used Skill Points For a Given Player.")
+            .withShortDescription("Get Used Skill Points")
+            .withPermission("alathraskills.get")
+            .executesPlayer(this::runCommand)
+            .register();
+    }
+
+    private void runCommand(Player player, CommandArguments args) {
+        if (args.get("targetPlayer") == null) {
+            player.sendMessage(
+                    ColorParser.of("Provide a value after the command to indicate target player.")
+                        .parseLegacy() // Parse legacy color codes
+                        .build()
+            );
+            return;
+        }
+        Integer dbReturnValue = SkillsPlayerManager.getUsedSkillPoints((Player) args.get("targetPlayer"));
+        String returnString =
+        		"Player with ID " +
+				((Player) args.get("targetPlayer")).getUniqueId() +
+				" has " +
+				Float.toString(dbReturnValue) +
+				" used skill points.";
+        player.sendMessage(
+                ColorParser.of(returnString)
+                    .parseLegacy() // Parse legacy color codes
+                    .build()
+        );
+    }
+}

--- a/src/main/java/io/github/alathra/alathraskills/api/commands/TestSetUsedSkillPointsCommandMemory.java
+++ b/src/main/java/io/github/alathra/alathraskills/api/commands/TestSetUsedSkillPointsCommandMemory.java
@@ -1,0 +1,57 @@
+package io.github.alathra.alathraskills.api.commands;
+
+import org.bukkit.entity.Player;
+
+import com.github.milkdrinkers.colorparser.ColorParser;
+
+import dev.jorel.commandapi.CommandAPICommand;
+import dev.jorel.commandapi.arguments.FloatArgument;
+import dev.jorel.commandapi.arguments.IntegerArgument;
+import dev.jorel.commandapi.arguments.PlayerArgument;
+import dev.jorel.commandapi.executors.CommandArguments;
+import io.github.alathra.alathraskills.api.SkillsPlayerManager;
+
+public class TestSetUsedSkillPointsCommandMemory {
+
+    public TestSetUsedSkillPointsCommandMemory() {
+        new CommandAPICommand("testSetUsedSkillPoints_memory")
+        	.withArguments(new PlayerArgument("targetPlayer"), new IntegerArgument("usedSkillPoints"))
+            .withFullDescription("Set Used Skill Points For a Given Player in Memory.")
+            .withShortDescription("Set Used Skill Points")
+            .withPermission("alathraskills.set")
+            .executesPlayer(this::runCommand)
+            .register();
+    }
+
+    private void runCommand(Player player, CommandArguments args) {
+        if (args.get("targetPlayer") == null) {
+            player.sendMessage(
+                    ColorParser.of("Provide a value after the command to indicate target player.")
+                        .parseLegacy() // Parse legacy color codes
+                        .build()
+            );
+            return;
+        }
+    	if (args.get("usedSkillPoints") == null) {
+            player.sendMessage(
+                    ColorParser.of("Provide a value after the player to indicate used skill points.")
+                        .parseLegacy() // Parse legacy color codes
+                        .build()
+            );
+        }
+
+        // TODO Make Async
+        SkillsPlayerManager.setPlayerUsedSkillPoints((Player) args.get("targetPlayer"), (Integer) args.get("usedSkillPoints"));
+        String returnString =
+        		"Player with ID " +
+				player.getUniqueId() +
+				" has had an used skill pionts value of " +
+				args.get("usedSkillPoints") +
+				" set.";
+        player.sendMessage(
+                ColorParser.of(returnString)
+                    .parseLegacy() // Parse legacy color codes
+                    .build()
+        );
+    }
+}

--- a/src/main/java/io/github/alathra/alathraskills/command/CommandHandler.java
+++ b/src/main/java/io/github/alathra/alathraskills/command/CommandHandler.java
@@ -6,13 +6,17 @@ import io.github.alathra.alathraskills.api.commands.TestAddSkillCommandMemory;
 import io.github.alathra.alathraskills.api.commands.TestDeleteSkillCommandMemory;
 import io.github.alathra.alathraskills.api.commands.TestGetAllSkillsCommandMemory;
 import io.github.alathra.alathraskills.api.commands.TestGetExerienceCommandMemory;
+import io.github.alathra.alathraskills.api.commands.TestGetUsedSkillPointsCommandMemory;
 import io.github.alathra.alathraskills.api.commands.TestSetExerienceCommandMemory;
+import io.github.alathra.alathraskills.api.commands.TestSetUsedSkillPointsCommandMemory;
 import io.github.alathra.alathraskills.db.commands.TestDeleteAllSkillsCommand;
 import io.github.alathra.alathraskills.db.commands.TestGetAllSkillsCommand;
 import io.github.alathra.alathraskills.db.commands.TestGetExerienceCommand;
+import io.github.alathra.alathraskills.db.commands.TestGetUsedSkillPointsCommand;
 import io.github.alathra.alathraskills.db.commands.TestHasSkillCommand;
 import io.github.alathra.alathraskills.db.commands.TestSetExerienceCommand;
 import io.github.alathra.alathraskills.db.commands.TestSetSkillCommand;
+import io.github.alathra.alathraskills.db.commands.TestSetUsedSkillPointsCommand;
 import dev.jorel.commandapi.CommandAPI;
 import dev.jorel.commandapi.CommandAPIBukkitConfig;
 
@@ -48,6 +52,11 @@ public class CommandHandler implements Reloadable {
         new TestDeleteSkillCommandMemory();
         new TestGetAllSkillsCommandMemory();
         new TestGetExerienceCommandMemory();
+        
+        new TestGetUsedSkillPointsCommand();
+        new TestGetUsedSkillPointsCommandMemory();
+        new TestSetUsedSkillPointsCommand();
+        new TestSetUsedSkillPointsCommandMemory();
     }
 
     @Override

--- a/src/main/java/io/github/alathra/alathraskills/db/commands/TestGetUsedSkillPointsCommand.java
+++ b/src/main/java/io/github/alathra/alathraskills/db/commands/TestGetUsedSkillPointsCommand.java
@@ -1,0 +1,48 @@
+package io.github.alathra.alathraskills.db.commands;
+
+import org.bukkit.entity.Player;
+
+import com.github.milkdrinkers.colorparser.ColorParser;
+
+import dev.jorel.commandapi.CommandAPICommand;
+import dev.jorel.commandapi.arguments.IntegerArgument;
+import dev.jorel.commandapi.arguments.PlayerArgument;
+import dev.jorel.commandapi.executors.CommandArguments;
+import io.github.alathra.alathraskills.db.DatabaseQueries;
+
+public class TestGetUsedSkillPointsCommand {
+
+    public TestGetUsedSkillPointsCommand() {
+        new CommandAPICommand("testGetUsedSkillPoints_db")
+        	.withArguments(new PlayerArgument("targetPlayer"))
+            .withFullDescription("Get Used Skill Points For a Given Player.")
+            .withShortDescription("Get Used Skill Points")
+            .withPermission("alathraskills.get")
+            .executesPlayer(this::runCommand)
+            .register();
+    }
+
+    private void runCommand(Player player, CommandArguments args) {
+        if (args.get("targetPlayer") == null) {
+            player.sendMessage(
+                    ColorParser.of("Provide a value after the command to indicate target player.")
+                        .parseLegacy() // Parse legacy color codes
+                        .build()
+            );
+            return;
+        }
+        // TODO Make Async
+        Integer dbReturnValue = DatabaseQueries.getUsedSkillPoints((Player) args.get("targetPlayer")).value1();
+        String returnString =
+        		"Player with ID " +
+				((Player) args.get("targetPlayer")).getUniqueId() +
+				" has " +
+				Float.toString(dbReturnValue) +
+				" used skill points.";
+        player.sendMessage(
+                ColorParser.of(returnString)
+                    .parseLegacy() // Parse legacy color codes
+                    .build()
+        );
+    }
+}

--- a/src/main/java/io/github/alathra/alathraskills/db/commands/TestSetUsedSkillPointsCommand.java
+++ b/src/main/java/io/github/alathra/alathraskills/db/commands/TestSetUsedSkillPointsCommand.java
@@ -1,0 +1,57 @@
+package io.github.alathra.alathraskills.db.commands;
+
+import org.bukkit.entity.Player;
+
+import com.github.milkdrinkers.colorparser.ColorParser;
+
+import dev.jorel.commandapi.CommandAPICommand;
+import dev.jorel.commandapi.arguments.FloatArgument;
+import dev.jorel.commandapi.arguments.IntegerArgument;
+import dev.jorel.commandapi.arguments.PlayerArgument;
+import dev.jorel.commandapi.executors.CommandArguments;
+import io.github.alathra.alathraskills.db.DatabaseQueries;
+
+public class TestSetUsedSkillPointsCommand {
+
+    public TestSetUsedSkillPointsCommand() {
+        new CommandAPICommand("testSetUsedSkillPoints_db")
+        	.withArguments(new PlayerArgument("targetPlayer"), new IntegerArgument("usedSkillPoints"))
+            .withFullDescription("Set Used Skill Points For a Given Player.")
+            .withShortDescription("Set Used Skill Points")
+            .withPermission("alathraskills.set")
+            .executesPlayer(this::runCommand)
+            .register();
+    }
+
+    private void runCommand(Player player, CommandArguments args) {
+        if (args.get("targetPlayer") == null) {
+            player.sendMessage(
+                    ColorParser.of("Provide a value after the command to indicate target player.")
+                        .parseLegacy() // Parse legacy color codes
+                        .build()
+            );
+            return;
+        }
+    	if (args.get("usedSkillPoints") == null) {
+            player.sendMessage(
+                    ColorParser.of("Provide a value after the player indicate number of used skill points.")
+                        .parseLegacy() // Parse legacy color codes
+                        .build()
+            );
+        }
+
+        // TODO Make Async
+        DatabaseQueries.setUsedSkillPoints((Player) args.get("targetPlayer"), (Integer) args.get("usedSkillPoints"));
+        String returnString =
+        		"Player with ID " +
+				player.getUniqueId() +
+				" has " +
+				args.get("usedSkillPoints") +
+				" set for their number of used skill points. ";
+        player.sendMessage(
+                ColorParser.of(returnString)
+                    .parseLegacy() // Parse legacy color codes
+                    .build()
+        );
+    }
+}

--- a/src/main/resources/db/migration/V2__create_used_skill_points_table.sql
+++ b/src/main/resources/db/migration/V2__create_used_skill_points_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS ${tablePrefix}player_used_skill_points (
+    uuid ${uuidType} NOT NULL,
+    skills_used INT NOT NULL,
+    PRIMARY KEY (uuid)
+)${tableDefaults};


### PR DESCRIPTION
Added Used Skill Points
- Table
- DB Commands (Get, Set)
- Memory Commands (Get, Set)
- Integration in Skills Player Manager
- Load on Join in Skills Player
- Save on Leave
- Fix Plugin Reload for Skills Player Manager (erroring out before leaving the plugin in a broken state)
- Fix disable order